### PR TITLE
groupsテーブル、membersテーブルの作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|name|string|index: true, null: false|
+|name|string|index: true,unique: true,null: false|
 
 ### Association
 - has_many :messages

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,2 @@
+class GroupsController < ApplicationController
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,2 +1,15 @@
 class GroupsController < ApplicationController
+
+  def new
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+  
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,5 +2,8 @@ class MessagesController < ApplicationController
 
   def index
   end
+
+  def create
+  end
   
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,8 @@
 class UsersController < ApplicationController
 
+  def index
+  end
+
   def edit
   end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,2 @@
+class Group < ApplicationRecord
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,2 +1,6 @@
 class Group < ApplicationRecord
+  has_many :messages
+  has_many :members
+  has_many :users, through: :members
+  validates :name, presence: true
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,2 +1,4 @@
 class Member < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,0 +1,2 @@
+class Member < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :messages
+  has_many :members
+  has_many :groups, through: :members
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
   root "messages#index"
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
+  resources :groups, only: [:new, :create, :edit, :update] do
+    resources :messages, only: [:index, :create]
+  end
 end

--- a/db/migrate/20190504062113_create_groups.rb
+++ b/db/migrate/20190504062113_create_groups.rb
@@ -1,0 +1,8 @@
+class CreateGroups < ActiveRecord::Migration[5.0]
+  def change
+    create_table :groups do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190504062113_create_groups.rb
+++ b/db/migrate/20190504062113_create_groups.rb
@@ -1,7 +1,7 @@
 class CreateGroups < ActiveRecord::Migration[5.0]
   def change
     create_table :groups do |t|
-
+      t.string :name, null: false, unique: true, index: true
       t.timestamps
     end
   end

--- a/db/migrate/20190504063732_create_members.rb
+++ b/db/migrate/20190504063732_create_members.rb
@@ -1,0 +1,8 @@
+class CreateMembers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :members do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190504063732_create_members.rb
+++ b/db/migrate/20190504063732_create_members.rb
@@ -1,7 +1,8 @@
 class CreateMembers < ActiveRecord::Migration[5.0]
   def change
     create_table :members do |t|
-
+      t.references :group, foreign_key: true
+      t.references :user, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190503094027) do
+ActiveRecord::Schema.define(version: 20190504062113) do
+
+  create_table "groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_groups_on_name", using: :btree
+  end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",                                null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190504062113) do
+ActiveRecord::Schema.define(version: 20190504063732) do
 
   create_table "groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",       null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_groups_on_name", using: :btree
+  end
+
+  create_table "members", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "group_id"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_members_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_members_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -33,4 +42,6 @@ ActiveRecord::Schema.define(version: 20190504062113) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "members", "groups"
+  add_foreign_key "members", "users"
 end


### PR DESCRIPTION
# WHAT
groupsテーブル、membersテーブルの作成

# WHY
ChatSpaceではメッセージのやり取りをするためのグループを作成する必要がある。
そのグループを保存するためのgroupsテーブルとusersテーブルとgroupsテーブルの中間テーブルに当たる
membersテーブルを作成することでグループを作成できるようになる。
このプルリクエストではコントローラ・モデルの作成、マイグレーションファイルの編集、テーブル作成、
ルーティングの設定を行った。

![](https://i.gyazo.com/32219a76d4d04a08202b0f8288f556df.png)


![](https://i.gyazo.com/5e965c0dadf353489ee4613d433b1c83.png)
