### PR TITLE
サイドバーのグループ部分に最新のメッセージを表示

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,12 @@ class Group < ApplicationRecord
   has_many :members
   has_many :users, through: :members
   validates :name, presence: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.body? ? last_message.body : "画像が投稿されています"
+    else
+      "まだメッセージはありません。"
+    end
+  end
 end

--- a/app/views/groups/_group.html.haml
+++ b/app/views/groups/_group.html.haml
@@ -4,4 +4,4 @@
       %p.group__group-name
         = group.name
       %p.group__latest-messages
-        睡眠は大切
+        = group.show_last_message

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -5,10 +5,12 @@
   .chat-main
     .main-header
       .current-group
-        %h2.current-group__name test
+        %h2.current-group__name
+          = @group.name
         %ul.member-list
           Member：
-          %li.member-list__member Mihou
+          %li.member-list__member
+            = current_user.name
       = link_to edit_group_path(params[:group_id]) do
         .main-header__edit-btn Edit
     .messages


### PR DESCRIPTION
# WHAT
サイドバーのグループ部分に最新のメッセージを表示

# WHY
ユーザーが投稿を行った時に最新のメッセージを表示するようにした。
またチャット画面でもグループ名、ユーザー名を表示するようにした。

![](https://i.gyazo.com/b8ae7a73958f4b46b76c1c60e9a0430a.png)
